### PR TITLE
Email fix

### DIFF
--- a/app/controllers/api/interest_submissions_controller.rb
+++ b/app/controllers/api/interest_submissions_controller.rb
@@ -3,9 +3,9 @@ class Api::InterestSubmissionsController < ApplicationController
   protect_from_forgery with: :exception
 
   def create
-    InterestSubmission.create(
-      params.permit(:icca_name, :icca_size, :country, :can_contact, :email)
-    )
+    submission = InterestSubmission.create(params.permit(:icca_name, :icca_size, :country, :can_contact, :email))
+
+    SubmissionMailer.create(submission).deliver
     head 201
   end
 end

--- a/app/controllers/api/interest_submissions_controller.rb
+++ b/app/controllers/api/interest_submissions_controller.rb
@@ -5,7 +5,7 @@ class Api::InterestSubmissionsController < ApplicationController
   def create
     submission = InterestSubmission.create(params.permit(:icca_name, :icca_size, :country, :can_contact, :email))
 
-    SubmissionMailer.create(submission).deliver
+    SubmissionMailer.create(submission).deliver_now
     head 201
   end
 end

--- a/app/mailers/submission_mailer.rb
+++ b/app/mailers/submission_mailer.rb
@@ -1,0 +1,8 @@
+class SubmissionMailer < ActionMailer::Base
+
+  def create(submission)
+    @submission = submission
+    @can_contact = @submission.can_contact ? 'Yes' : 'No'
+    mail(to: t("home_page.destination_email_address"), from: @submission.email, subject: "New ICCA site: #{@submission.icca_name}")
+  end
+end

--- a/app/mailers/submission_mailer.rb
+++ b/app/mailers/submission_mailer.rb
@@ -3,6 +3,6 @@ class SubmissionMailer < ActionMailer::Base
   def create(submission)
     @submission = submission
     @can_contact = @submission.can_contact ? 'Yes' : 'No'
-    mail(to: t("home_page.destination_email_address"), from: @submission.email, subject: "New ICCA site: #{@submission.icca_name}")
+    mail(to: t("home_page.destination_email_address"), from: ENV['MAILER_USERNAME'], subject: "New ICCA site: #{@submission.icca_name}")
   end
 end

--- a/app/views/submission_mailer/create.html.erb
+++ b/app/views/submission_mailer/create.html.erb
@@ -3,6 +3,7 @@
 <p>A new ICCA site was submitted with the following details:</p>
 
 <ul>
+  <li>Email: <%= @submission.email %></li>
   <li>ICCA site: <%= @submission.icca_name %></li>
   <li>ICCA size: <%= @submission.icca_size %></li>
   <li>Country: <%= @submission.country %></li>

--- a/app/views/submission_mailer/create.html.erb
+++ b/app/views/submission_mailer/create.html.erb
@@ -1,0 +1,13 @@
+<p>Hello,</p>
+
+<p>A new ICCA site was submitted with the following details:</p>
+
+<ul>
+  <li>ICCA site: <%= @submission.icca_site %></li>
+  <li>ICCA size: <%= @submission.icca_size %></li>
+  <li>Country: <%= @submission.country %></li>
+  <li>Can contact: <%= @can_contact %></li>
+</ul>
+
+<p>Best regards,</p>
+<p>The ICCA Registry</p>

--- a/app/views/submission_mailer/create.html.erb
+++ b/app/views/submission_mailer/create.html.erb
@@ -3,7 +3,7 @@
 <p>A new ICCA site was submitted with the following details:</p>
 
 <ul>
-  <li>ICCA site: <%= @submission.icca_site %></li>
+  <li>ICCA site: <%= @submission.icca_name %></li>
   <li>ICCA size: <%= @submission.icca_size %></li>
   <li>Country: <%= @submission.country %></li>
   <li>Can contact: <%= @can_contact %></li>

--- a/app/views/submission_mailer/create.text.erb
+++ b/app/views/submission_mailer/create.text.erb
@@ -4,7 +4,7 @@ A new ICCA site was submitted with the following details:
 
 =========================================================
 
-
+Email: <%= @submission.email %>
 ICCA site: <%= @submission.icca_name %>
 ICCA size: <%= @submission.icca_size %>
 Country: <%= @submission.country %>

--- a/app/views/submission_mailer/create.text.erb
+++ b/app/views/submission_mailer/create.text.erb
@@ -1,0 +1,15 @@
+Hello,
+
+A new ICCA site was submitted with the following details:
+
+=========================================================
+
+
+ICCA site: <%= @submission.icca_name %>
+ICCA size: <%= @submission.icca_size %>
+Country: <%= @submission.country %>
+Can contact: <%= @can_contact %>
+
+
+Best regards,
+The ICCA Registry

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,8 +41,8 @@ Rails.application.configure do
   config.assets.raise_runtime_errors = true
 
   config.action_mailer.delivery_method = :smtp
-  host = 'localhost:3000'
   config.action_mailer.default_url_options = { :host => 'localhost:3000', protocol: 'http' }
+  config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.smtp_settings = {
     domain: ENV['MAILER_DOMAIN'],

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -22,7 +22,6 @@ Rails.application.configure do
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 
-  config.action_mailer.delivery_method = :smtp
 
   # Store files locally.
   config.active_storage.service = :development
@@ -40,6 +39,20 @@ Rails.application.configure do
   # Checks for improperly declared sprockets dependencies.
   # Raises helpful error messages.
   config.assets.raise_runtime_errors = true
+
+  config.action_mailer.delivery_method = :smtp
+  host = 'localhost:3000'
+  config.action_mailer.default_url_options = { :host => 'localhost:3000', protocol: 'http' }
+
+  config.action_mailer.smtp_settings = {
+    domain: ENV['MAILER_DOMAIN'],
+    address: ENV['MAILER_ADDRESS'],
+    port: 587,
+    authentication: :login,
+    enable_starttls_auto: true,
+    user_name: ENV['MAILER_USERNAME'],
+    password: ENV['MAILER_PASSWORD']
+  }
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -22,6 +22,8 @@ Rails.application.configure do
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 
+  config.action_mailer.delivery_method = :smtp
+
   # Store files locally.
   config.active_storage.service = :development
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,6 +77,20 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.default_url_options = { :host => ENV['MAILER_PRODUCTION_HOST'] }
+  config.action_mailer.raise_delivery_errors = true
+
+  config.action_mailer.smtp_settings = {
+    domain: ENV['MAILER_DOMAIN'],
+    address: ENV['MAILER_ADDRESS'],
+    port: 587,
+    authentication: :login,
+    enable_starttls_auto: true,
+    user_name: ENV['MAILER_USERNAME'],
+    password: ENV['MAILER_PASSWORD']
+  }
+
   # Store files on Amazon S3.
   config.active_storage.service = :production
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -79,5 +79,19 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.default_url_options = { :host => ENV['MAILER_STAGING_HOST'] }
+  config.action_mailer.raise_delivery_errors = true
+
+  config.action_mailer.smtp_settings = {
+    domain: ENV['MAILER_DOMAIN'],
+    address: ENV['MAILER_ADDRESS'],
+    port: 587,
+    authentication: :login,
+    enable_starttls_auto: true,
+    user_name: ENV['MAILER_USERNAME'],
+    password: ENV['MAILER_PASSWORD']
+  }
+
   # config.active_storage.service = :staging
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,8 +38,7 @@ en:
     download_manual_fr: "Download the ICCA Data Manual (Français)"
     interest_banner: "Are you interested in engaging with the ICCA Registry?"
     interest_banner_text: "If you would like to express your interest, or would like further information, please let us know"
-    # destination_email_address: "iccaregistry@unep-wcmc.org"
-    destination_email_address: "argwarbagle@sharklasers.com"
+    destination_email_address: "iccaregistry@unep-wcmc.org"
     interest_modal:
       cancel: "Cancel"
       country: "Country"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,8 @@ en:
     download_manual_fr: "Download the ICCA Data Manual (Français)"
     interest_banner: "Are you interested in engaging with the ICCA Registry?"
     interest_banner_text: "If you would like to express your interest, or would like further information, please let us know"
+    # destination_email_address: "iccaregistry@unep-wcmc.org"
+    destination_email_address: "argwarbagle@sharklasers.com"
     interest_modal:
       cancel: "Cancel"
       country: "Country"

--- a/lib/tasks/db_check.rake
+++ b/lib/tasks/db_check.rake
@@ -76,8 +76,11 @@ namespace :db_check do
 					attachments.each do |attachment|
 						if instance.send(attachment).path.blank? || !File.exist?(instance.send(attachment).path)
               unless instance.send(attachment).path.nil?
-                files_to_download << 'public/system/' + instance.send(attachment).path.split('/').slice(6..-1).join('/') if !Rails.env.development?
-							  files_to_download << instance.send(attachment).path.split('/').slice(6..-1).join('/')
+                if !Rails.env.development?
+                  files_to_download << instance.send(attachment).path.split('/').slice(8..-1).join('/')
+                else
+							   files_to_download << instance.send(attachment).path.split('/').slice(6..-1).join('/')
+                end
               end
 						end
 					end

--- a/spec/mailers/previews/submission_mailer_preview.rb
+++ b/spec/mailers/previews/submission_mailer_preview.rb
@@ -1,0 +1,9 @@
+# Preview all emails at http://localhost:3000/rails/mailers/submission_mailer
+class SubmissionMailerPreview < ActionMailer::Preview
+   def create
+    # Set up a temporary order for the preview
+    submission = InterestSubmission.new(icca_name: "Test", email: "joe@gmail.com", country: 'test', icca_size: "test", can_contact: true, )
+
+    SubmissionMailer.create(submission)
+  end
+end


### PR DESCRIPTION
Set up the register form on the homepage to send emails to iccaregistry@unep-wcmc.org when someone makes a submission, instead of just storing it in the CMS. Jess has confirmed that it works when I sent a test email from the development environment.