### PR TITLE
fixed map reloads

### DIFF
--- a/app/assets/javascripts/common.js.coffee
+++ b/app/assets/javascripts/common.js.coffee
@@ -1,4 +1,4 @@
-$(document).ready( ->
+$(document).on('turbolinks:load', () ->
   if ($mapEl = $('#map')).length > 0
     try
       new Map($mapEl)
@@ -25,4 +25,5 @@ $(document).ready( ->
 
   setTimeout((-> $(".banner").addClass("animated")), 750)
 )
+
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,8 @@
   <% end %>
 
   <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+  <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+  <%= javascript_include_tag "application", 'data-turbolinks-track': 'reload' %>
 </head>
 <body>
   <main class="body-container">
@@ -33,8 +35,7 @@
 
   <%= render "layouts/application/footer" %>
 
-  <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
-  <%= javascript_include_tag "application" %>
+
 
   <% if Rails.env == 'production' %>
     <%= render 'shared/google_analytics' %>


### PR DESCRIPTION
Move `javascript_include_tag` (Sprockets) into head as well as CartoDB script, and used new CoffeeScript syntax for Turbolinks removing the constant reloading issue. 