### PR TITLE
ICCA Sites may now be edited

### DIFF
--- a/app/controllers/admin/icca_sites_controller.rb
+++ b/app/controllers/admin/icca_sites_controller.rb
@@ -12,6 +12,9 @@ class Admin::IccaSitesController < Comfy::Admin::Cms::BaseController
     name = icca_site_params[:name]
 
     @icca_site.update(icca_site_params)
+
+    # CMS pages do not automatically update to reflect the new name of the 
+    # ICCA site!
     @icca_site.pages.update(
       label: name,
       slug: name.downcase.split.join('-')

--- a/app/controllers/admin/icca_sites_controller.rb
+++ b/app/controllers/admin/icca_sites_controller.rb
@@ -9,8 +9,13 @@ class Admin::IccaSitesController < Comfy::Admin::Cms::BaseController
   end
 
   def update
-    @icca_site.update(icca_site_params)
+    name = icca_site_params[:name]
 
+    @icca_site.update(icca_site_params)
+    @icca_site.pages.update(
+      label: name,
+      slug: name.downcase.split.join('-')
+    )
     redirect_to action: :index
   end
 

--- a/app/views/admin/icca_sites/edit.html.erb
+++ b/app/views/admin/icca_sites/edit.html.erb
@@ -4,8 +4,8 @@
   </h2>
 </div>
 
-<%= bootstrap_form_for @icca_site, url: {action: "update"} do |f| %>
-  <%= f.text_field :name, disabled: true %>
+<%= bootstrap_form_with(model: [:admin, @icca_site]) do |f| %>
+  <%= f.text_field :name %>
   <%= f.text_field :lat %>
   <%= f.text_field :lon %>
 


### PR DESCRIPTION
Ticket

https://unep-wcmc.codebasehq.com/projects/icca-registry-website/tickets/33

ICCA Site names can now be directly edited via the CMS (they were previously disabled). Additionally, the CMS page titles and slugs will now update to reflect the new name via the controller, as they do not automatically update.