### PR TITLE
editing the label of a cms page no longer creates a new icca site

### DIFF
--- a/app/models/concerns/icca_links.rb
+++ b/app/models/concerns/icca_links.rb
@@ -17,7 +17,7 @@ module IccaLinks
       
       if self.icca_site 
         IccaSite.where(id: self.icca_site.id).update(name: self.label)
-        self.slug = self.label.downcase.split().join('-')
+        self.slug = self.label.downcase.split.join('-')
       else
         self.icca_site = IccaSite.find_or_create_by(
           name: self.label,

--- a/app/models/concerns/icca_links.rb
+++ b/app/models/concerns/icca_links.rb
@@ -14,11 +14,16 @@ module IccaLinks
 
     def link_icca_site
       return true if self.parent.try(:country_id).nil?
-
-      self.icca_site = IccaSite.find_or_create_by(
-        name: self.label,
-        country: self.parent.country
-      )
+      
+      if self.icca_site 
+        IccaSite.where(id: self.icca_site.id).update(name: self.label)
+        self.slug = self.label.downcase.split().join('-')
+      else
+        self.icca_site = IccaSite.find_or_create_by(
+          name: self.label,
+          country: self.parent.country
+        )
+      end
     end
 
     def link_country


### PR DESCRIPTION
**Ticket**

https://unep-wcmc.codebasehq.com/projects/icca-registry-website/tickets/10

Editing the label of a CMS page (specifically the case study pages which belong to an ICCA site) would create a new ICCA site every time and disrupt the existing associations. Now the script will check that a site exists before saving, and if so, it will update the name of that site, along with the slug of the CMS page. If not, it will proceed as per the old method of creating a new ICCA site. 