### PR TITLE
added config settings in CMS initializer

### DIFF
--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,5 +1,5 @@
 set :stage, :staging
-set :branch, "upgrading-cms-part-two"
+set :branch, "develop"
 
 server "web-supported-staging.linode.unep-wcmc.org", user: 'wcmc', roles: %w{app web db}
 

--- a/config/initializers/comfortable_mexican_sofa.rb
+++ b/config/initializers/comfortable_mexican_sofa.rb
@@ -1,6 +1,11 @@
 # encoding: utf-8
 
 ComfortableMexicanSofa.configure do |config|
+  config.enable_seeds = Rails.env.development?
+
+  # N.B. The name of the site identifier is icca-registry (for the EN version)
+  config.seeds_path = 'cms/icca-registry/'
+  
   # Title of the admin area
   #   config.cms_title = 'ComfortableMexicanSofa CMS Engine'
 


### PR DESCRIPTION
Set up the Comfy import/export CMS seeds feature so that it becomes easier to set up locally via the Comfy rake task. 

TODO: Put in example commands in the Readme. 