### PR TITLE
Captcha fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'aws-sdk', '~> 1.6'
 # Accessing S3 bucket using AWS gem instead of open-uri
 gem 'aws-sdk-s3'
 gem 'appsignal', '~> 2.2.1'
-gem 'invisible_captcha', '~> 0.9.2'
+gem 'invisible_captcha'
 gem 'paperclip'
 
 # Assets

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'pg_search'
 
 group :development, :test do
   gem 'byebug'
+  gem 'letter_opener'
   gem 'rspec-rails', '~> 3.9'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,10 +132,10 @@ GEM
       haml (>= 4.0, < 6)
       nokogiri (>= 1.6.0)
       ruby_parser (~> 3.5)
-    i18n (1.8.3)
+    i18n (1.8.4)
       concurrent-ruby (~> 1.0)
-    invisible_captcha (0.9.3)
-      rails (>= 3.2.0)
+    invisible_captcha (1.0.1)
+      rails (>= 4.2)
     jmespath (1.4.0)
     jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
@@ -144,7 +144,7 @@ GEM
     json (1.8.6)
     kramdown (2.2.1)
       rexml
-    loofah (2.5.0)
+    loofah (2.6.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -177,7 +177,7 @@ GEM
       activerecord (>= 4.2)
       activesupport (>= 4.2)
     public_suffix (4.0.5)
-    rack (2.2.2)
+    rack (2.2.3)
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -287,7 +287,7 @@ GEM
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
       railties (>= 4.2)
-    websocket-driver (0.7.2)
+    websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
 
@@ -307,7 +307,7 @@ DEPENDENCIES
   comfortable_mexican_sofa (~> 2.0.0)
   comfy_bootstrap_form (~> 4.0.3)
   dotenv-rails
-  invisible_captcha (~> 0.9.2)
+  invisible_captcha
   nokogiri (~> 1.6.7.2)
   paperclip
   pg (~> 0.18.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,6 +144,10 @@ GEM
     json (1.8.6)
     kramdown (2.2.1)
       rexml
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    letter_opener (1.7.0)
+      launchy (~> 2.2)
     loofah (2.6.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -308,6 +312,7 @@ DEPENDENCIES
   comfy_bootstrap_form (~> 4.0.3)
   dotenv-rails
   invisible_captcha
+  letter_opener
   nokogiri (~> 1.6.7.2)
   paperclip
   pg (~> 0.18.4)

--- a/app/controllers/api/interest_submissions_controller.rb
+++ b/app/controllers/api/interest_submissions_controller.rb
@@ -1,5 +1,5 @@
 class Api::InterestSubmissionsController < ApplicationController
-  invisible_captcha only: [:create], honeypot: :last_name
+  invisible_captcha only: [:create], honeypot: :last_name, on_spam: :spam_caught
   protect_from_forgery with: :exception
 
   def create
@@ -7,5 +7,12 @@ class Api::InterestSubmissionsController < ApplicationController
 
     SubmissionMailer.create(submission).deliver_now
     head 201
+  end
+
+  private 
+
+
+  def spam_caught
+    redirect_to root_path
   end
 end

--- a/app/controllers/api/interest_submissions_controller.rb
+++ b/app/controllers/api/interest_submissions_controller.rb
@@ -5,9 +5,7 @@ class Api::InterestSubmissionsController < ApplicationController
   def create
     submission = InterestSubmission.create(params.permit(:icca_name, :icca_size, :country, :can_contact, :email))
 
-    SubmissionMailer.create(submission).deliver_nows
+    SubmissionMailer.create(submission).deliver_now
     head 201
   end
-
-  private 
 end

--- a/app/controllers/api/interest_submissions_controller.rb
+++ b/app/controllers/api/interest_submissions_controller.rb
@@ -1,18 +1,13 @@
 class Api::InterestSubmissionsController < ApplicationController
-  invisible_captcha only: [:create], honeypot: :last_name, on_spam: :spam_caught
+  invisible_captcha only: [:create], honeypot: :last_name
   protect_from_forgery with: :exception
 
   def create
     submission = InterestSubmission.create(params.permit(:icca_name, :icca_size, :country, :can_contact, :email))
 
-    SubmissionMailer.create(submission).deliver_now
+    SubmissionMailer.create(submission).deliver_nows
     head 201
   end
 
   private 
-
-
-  def spam_caught
-    redirect_to root_path
-  end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,7 +14,7 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
@@ -40,19 +40,20 @@ Rails.application.configure do
   # Raises helpful error messages.
   config.assets.raise_runtime_errors = true
 
-  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.perform_deliveries = :true
   config.action_mailer.default_url_options = { :host => 'localhost:3000', protocol: 'http' }
-  config.action_mailer.raise_delivery_errors = true
+  
 
-  config.action_mailer.smtp_settings = {
-    domain: ENV['MAILER_DOMAIN'],
-    address: ENV['MAILER_ADDRESS'],
-    port: 587,
-    authentication: :login,
-    enable_starttls_auto: true,
-    user_name: ENV['MAILER_USERNAME'],
-    password: ENV['MAILER_PASSWORD']
-  }
+  # config.action_mailer.smtp_settings = {
+  #   domain: ENV['MAILER_DOMAIN'],
+  #   address: ENV['MAILER_ADDRESS'],
+  #   port: 587,
+  #   authentication: :login,
+  #   enable_starttls_auto: true,
+  #   user_name: ENV['MAILER_USERNAME'],
+  #   password: ENV['MAILER_PASSWORD']
+  # }
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true

--- a/config/initializers/invisible_captcha.rb
+++ b/config/initializers/invisible_captcha.rb
@@ -1,0 +1,8 @@
+InvisibleCaptcha.setup do |config|
+    config.visual_honeypots = false
+end
+
+ActiveSupport::Notifications.subscribe('invisible_captcha.spam_caught') do |spam|
+    captured_spam = spam.extract_options!
+    Rails.logger.info("#{captured_spam} caught!")        
+end

--- a/config/initializers/invisible_captcha.rb
+++ b/config/initializers/invisible_captcha.rb
@@ -2,7 +2,3 @@ InvisibleCaptcha.setup do |config|
     config.visual_honeypots = false
 end
 
-ActiveSupport::Notifications.subscribe('invisible_captcha.spam_caught') do |spam|
-    captured_spam = spam.extract_options!
-    Rails.logger.info("#{captured_spam} caught!")        
-end


### PR DESCRIPTION
**Ticket**

https://unep-wcmc.codebasehq.com/projects/icca-registry-website/tickets/38

Did some testing with Invisible Captcha to verify that it was working as intended, as there were reports of spam coming through which were not being caught. However, after also looking at the production logs, I could see that the spam attempts were successfully being redirected back to the homepage ~without~ submitting an email, it's just that the spam attempts were being logged as a hash. 

In any case, I've added back `gem_opener` and updated `invisible_captcha`, along with an initializer for future configuration if needed.