### PR TITLE
links made bold and underlined in news article

### DIFF
--- a/app/assets/stylesheets/icca_registry/news-article.scss
+++ b/app/assets/stylesheets/icca_registry/news-article.scss
@@ -1,6 +1,11 @@
 .news-article { 
   &__content {
     @include text(body);
+
+    a { 
+      @include text(body, bold);
+      text-decoration: underline;
+    }
   }
 
   &__date {

--- a/app/assets/stylesheets/icca_registry/page.scss
+++ b/app/assets/stylesheets/icca_registry/page.scss
@@ -5,23 +5,23 @@
     }
 
     p {
-      @include text(body);
       @include space-small(margin-top);
+      @include text(body);
     }
     
     h1 {
-      @include text(xxlarge, bold);
       @include space-small(margin-top);
+      @include text(xxlarge, bold);
     }
 
     h2 {
-      @include text(xlarge, bold);
       @include space-small(margin-top);
+      @include text(xlarge, bold);
     }
 
     h3 {
-      @include text(large, bold);
       @include space-small(margin-top);
+      @include text(large, bold);
     }
 
     img {


### PR DESCRIPTION
**Ticket**

https://unep-wcmc.codebasehq.com/projects/icca-registry-website/tickets/45

Links are now in bold and underlined in news articles.