### PR TITLE
Feat/validation icca sites

### DIFF
--- a/app/controllers/admin/icca_sites_controller.rb
+++ b/app/controllers/admin/icca_sites_controller.rb
@@ -14,14 +14,15 @@ class Admin::IccaSitesController < Comfy::Admin::Cms::BaseController
     updated_site = @icca_site.update(icca_site_params)
 
     if updated_site
-      # CMS pages do not automatically update to reflect the new name of the 
-      # ICCA site!
+      # CMS pages do not automatically update to reflect the new name of the ICCA site!
+      normalised_name = I18n.transliterate(name).gsub(/[():'&]/, '')
+
       @icca_site.pages.update(
         label: name,
-        slug: name.downcase.split.join('-')
+        slug: normalised_name.downcase.split.join('-')
       )
       redirect_to action: :index
-    else 
+    else
       flash[:error] = @icca_site.errors.full_messages.first
       redirect_to action: :edit
     end

--- a/app/controllers/admin/icca_sites_controller.rb
+++ b/app/controllers/admin/icca_sites_controller.rb
@@ -11,15 +11,20 @@ class Admin::IccaSitesController < Comfy::Admin::Cms::BaseController
   def update
     name = icca_site_params[:name]
 
-    @icca_site.update(icca_site_params)
+    updated_site = @icca_site.update(icca_site_params)
 
-    # CMS pages do not automatically update to reflect the new name of the 
-    # ICCA site!
-    @icca_site.pages.update(
-      label: name,
-      slug: name.downcase.split.join('-')
-    )
-    redirect_to action: :index
+    if updated_site
+      # CMS pages do not automatically update to reflect the new name of the 
+      # ICCA site!
+      @icca_site.pages.update(
+        label: name,
+        slug: name.downcase.split.join('-')
+      )
+      redirect_to action: :index
+    else 
+      flash[:error] = @icca_site.errors.full_messages.first
+      redirect_to action: :edit
+    end
   end
 
   def destroy

--- a/app/controllers/admin/icca_sites_controller.rb
+++ b/app/controllers/admin/icca_sites_controller.rb
@@ -23,7 +23,7 @@ class Admin::IccaSitesController < Comfy::Admin::Cms::BaseController
       )
       redirect_to action: :index
     else
-      flash[:error] = @icca_site.errors.full_messages.first
+      flash[:error] = @icca_site.errors.full_messages.join(', ')
       redirect_to action: :edit
     end
   end

--- a/app/models/icca_site.rb
+++ b/app/models/icca_site.rb
@@ -3,7 +3,7 @@ class IccaSite < ApplicationRecord
   belongs_to :country
   has_many :pages, class_name: "Comfy::Cms::Page"
 
-  validates :lon, :lat, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180 }
+  validates :lon, :lat, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180, message: 'must be valid' }
 
   private
 

--- a/app/models/icca_site.rb
+++ b/app/models/icca_site.rb
@@ -3,6 +3,8 @@ class IccaSite < ApplicationRecord
   belongs_to :country
   has_many :pages, class_name: "Comfy::Cms::Page"
 
+  validates :lon, :lat, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180 }
+
   private
 
   def safe_to_destroy

--- a/app/models/icca_site.rb
+++ b/app/models/icca_site.rb
@@ -3,7 +3,8 @@ class IccaSite < ApplicationRecord
   belongs_to :country
   has_many :pages, class_name: "Comfy::Cms::Page"
 
-  validates :lon, :lat, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180, message: 'must be valid' }
+  validates :lon, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180, message: 'must be valid' }
+  validates :lat, numericality: { greater_than_or_equal_to: -90, less_than_or_equal_to: 90, message: 'must be valid' } 
 
   private
 

--- a/app/models/icca_site.rb
+++ b/app/models/icca_site.rb
@@ -3,8 +3,8 @@ class IccaSite < ApplicationRecord
   belongs_to :country
   has_many :pages, class_name: "Comfy::Cms::Page"
 
-  validates :lon, allow_blank: true, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180, message: 'must be within +/- 180 and must only contain numbers/.' }
-  validates :lat, allow_blank: true, numericality: { greater_than_or_equal_to: -90, less_than_or_equal_to: 90, message: 'must be within +/- 90 and must only contain numbers/.' } 
+  validates :lon, allow_blank: true, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180, message: "must be within +/- 180 and must only contain numbers and/or a '.'" }
+  validates :lat, allow_blank: true, numericality: { greater_than_or_equal_to: -90, less_than_or_equal_to: 90, message: "must be within +/- 90 and must only contain numbers and/or a '.'" } 
 
   private
 

--- a/app/models/icca_site.rb
+++ b/app/models/icca_site.rb
@@ -3,8 +3,8 @@ class IccaSite < ApplicationRecord
   belongs_to :country
   has_many :pages, class_name: "Comfy::Cms::Page"
 
-  validates :lon, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180, message: 'must be valid' }
-  validates :lat, numericality: { greater_than_or_equal_to: -90, less_than_or_equal_to: 90, message: 'must be valid' } 
+  validates :lon, allow_blank: true, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180, message: 'must be within +/- 180 and must only contain numbers/.' }
+  validates :lat, allow_blank: true, numericality: { greater_than_or_equal_to: -90, less_than_or_equal_to: 90, message: 'must be within +/- 90 and must only contain numbers/.' } 
 
   private
 

--- a/db/migrate/20210301221411_add_precision_to_icca_site_coordinates.rb
+++ b/db/migrate/20210301221411_add_precision_to_icca_site_coordinates.rb
@@ -1,7 +1,7 @@
 class AddPrecisionToIccaSiteCoordinates < ActiveRecord::Migration[5.2]
   def up
-    change_column :icca_sites, :lat, :decimal, precision: 4, scale: 2
-    change_column :icca_sites, :lon, :decimal, precision: 5, scale: 2
+    change_column :icca_sites, :lat, :decimal, precision: 9, scale: 7
+    change_column :icca_sites, :lon, :decimal, precision: 10, scale: 7
   end
 
   def down 

--- a/db/migrate/20210301221411_add_precision_to_icca_site_coordinates.rb
+++ b/db/migrate/20210301221411_add_precision_to_icca_site_coordinates.rb
@@ -1,0 +1,11 @@
+class AddPrecisionToIccaSiteCoordinates < ActiveRecord::Migration[5.2]
+  def up
+    change_column :icca_sites, :lat, :decimal, precision: 5, scale: 2
+    change_column :icca_sites, :lon, :decimal, precision: 5, scale: 2
+  end
+
+  def down 
+    change_column :icca_sites, :lat, :float
+    change_column :icca_sites, :lon, :float
+  end
+end

--- a/db/migrate/20210301221411_add_precision_to_icca_site_coordinates.rb
+++ b/db/migrate/20210301221411_add_precision_to_icca_site_coordinates.rb
@@ -1,6 +1,6 @@
 class AddPrecisionToIccaSiteCoordinates < ActiveRecord::Migration[5.2]
   def up
-    change_column :icca_sites, :lat, :decimal, precision: 5, scale: 2
+    change_column :icca_sites, :lat, :decimal, precision: 4, scale: 2
     change_column :icca_sites, :lon, :decimal, precision: 5, scale: 2
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_28_142128) do
+ActiveRecord::Schema.define(version: 2021_03_01_221411) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -173,8 +173,8 @@ ActiveRecord::Schema.define(version: 2020_05_28_142128) do
     t.integer "country_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.float "lon"
-    t.float "lat"
+    t.decimal "lon", precision: 5, scale: 2
+    t.decimal "lat", precision: 5, scale: 2
   end
 
   create_table "interest_submissions", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -174,7 +174,7 @@ ActiveRecord::Schema.define(version: 2021_03_01_221411) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.decimal "lon", precision: 5, scale: 2
-    t.decimal "lat", precision: 5, scale: 2
+    t.decimal "lat", precision: 4, scale: 2
   end
 
   create_table "interest_submissions", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -173,8 +173,8 @@ ActiveRecord::Schema.define(version: 2021_03_01_221411) do
     t.integer "country_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.decimal "lon", precision: 5, scale: 2
-    t.decimal "lat", precision: 4, scale: 2
+    t.decimal "lon", precision: 10, scale: 7
+    t.decimal "lat", precision: 9, scale: 7
   end
 
   create_table "interest_submissions", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
- Prevent longitude values from exceeding +/- 180 and latitude from exceeding +/- 90.
- Force them to adopt 7 d.p. 
- Display validation error message when trying to enter an invalid latitude/longitude.
- Prevent update of ICCA sites from causing the relevant page slug to use the original, non-transliterated (i.e. having non-ASCII characters) name of the site. 

**Requirements**

`rails db:migrate`